### PR TITLE
Add TEMP_ASSET_PATH env var

### DIFF
--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -10,6 +10,9 @@ var _ = require("lodash");
 var mochaSettings = require("./settings");
 
 var MochaTestRun = function (options) {
+  // Share assets directory with mocha tests
+  process.env.TEMP_ASSET_PATH = options.tempAssetPath;
+
   _.extend(this, options);
 };
 


### PR DESCRIPTION
To be able to access magellan temp dir from mocha tests