### PR TITLE
Add option to include a list of files to test

### DIFF
--- a/lib/single_test_filter.js
+++ b/lib/single_test_filter.js
@@ -10,10 +10,10 @@ module.exports = function (tests, filename) {
   logger.log("Using mocha test filter: ", filename);
 
   return tests.filter(function (test) {
-    filename = filename.split(",");
-    if (filename instanceof Array) {
-      for (var i = 0; i < filename.length; i++) {
-        if (path.resolve(test.filename.trim()) === path.resolve(filename[i].trim())) {
+    var fileArray = filename.split(",");
+    if (fileArray instanceof Array) {
+      for (var i = 0; i < fileArray.length; i++) {
+        if (path.resolve(test.filename.trim()) === path.resolve(fileArray[i].trim())) {
           return true;
         }
       }

--- a/lib/single_test_filter.js
+++ b/lib/single_test_filter.js
@@ -9,11 +9,14 @@ module.exports = function (tests, filename) {
   logger.prefix = "Mocha Plugin";
   logger.log("Using mocha test filter: ", filename);
 
-  var searchedForPath = path.resolve(filename);
-
-  return tests.filter(function (t) {
-    if (t.filename === searchedForPath) {
-      return true;
+  return tests.filter(function (test) {
+    filename = filename.split(",");
+    if (filename instanceof Array) {
+      for (var i = 0; i < filename.length; i++) {
+        if (path.resolve(test.filename.trim()) === path.resolve(filename[i].trim())) {
+          return true;
+        }
+      }
     }
   });
 };


### PR DESCRIPTION
This PR adds the option to use a comma separated list of files instead of just a single file for the `--test` parameter.

The best way to test is to update packages in wp-calypso to this commit and then try running magellan (see run.sh in wp-calypso) with the `--test=` parameter. Try using a single file and a list of files.