### PR TITLE
Add support for using a list of suitetags

### DIFF
--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -24,7 +24,7 @@ module.exports = function (settings) {
 
   if ( mochaSettings.suiteTag !== undefined ) {
     reporter = path.resolve(__dirname, "suite_capture.js");
-    args.push("--reporter-options", "tag=" + mochaSettings.suiteTag);
+    args.push("--reporter-options", "tags=" + mochaSettings.suiteTag);
   }
 
   args.push("--reporter", reporter);

--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -8,12 +8,12 @@ var path = require("path");
 var spawnSync = require("child_process").spawnSync;
 var Locator = require("./locator");
 var mochaSettings = require("./settings");
-var reporter = path.resolve(__dirname, "test_capture.js");
 var logger = require("testarmada-logger");
 
 module.exports = function (settings) {
   logger.prefix = "Mocha Plugin";
   var OUTPUT_PATH = path.resolve(settings.tempDir, "get_mocha_tests.json");
+  var reporter = path.resolve(__dirname, "test_capture.js");
 
   if (!fs.existsSync(settings.tempDir)) {
     fs.mkdirSync(settings.tempDir);
@@ -22,7 +22,7 @@ module.exports = function (settings) {
   var cmd = "./node_modules/.bin/mocha";
   var args = [];
 
-  if ( mochaSettings.suiteTag !== undefined ) {
+  if (mochaSettings.suiteTag !== undefined) {
     reporter = path.resolve(__dirname, "suite_capture.js");
     args.push("--reporter-options", "tags=" + mochaSettings.suiteTag);
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  mocha_args: {
+  mocha_args: { // eslint-disable-line camelcase
     example: "'-R reporter'",
     description: "Append runtime command line arguments onto mocha"
   },
@@ -11,7 +11,7 @@ module.exports = {
   },
   suiteTag: {
     example: "tag1;tag2",
-    description: "Run all test suites (not individual tests) that match a list of semi-colon delimited tags (eg: tag1;tag2)"
+    description: "Run all test suites (not ind. tests) that match a list of semi-colon delimited tags" // eslint-disable-line max-len
   },
   group: {
     example: "prefix/path",

--- a/lib/help.js
+++ b/lib/help.js
@@ -10,8 +10,8 @@ module.exports = {
     description: "Run all tests that match a list of comma-delimited tags (eg: tag1,tag2)"
   },
   suiteTag: {
-    example: "tag",
-    description: "Run all test suites (not individual tests) that match the given tag"
+    example: "tag1;tag2",
+    description: "Run all test suites (not individual tests) that match a list of semi-colon delimited tags (eg: tag1;tag2)"
   },
   group: {
     example: "prefix/path",

--- a/lib/suite_capture.js
+++ b/lib/suite_capture.js
@@ -11,7 +11,7 @@ var _ = require("lodash");
 function getSuites(suite, wantedTag) {
   var suites = [];
 
-  if (suite.title.indexOf("@" + wantedTag) > -1) {
+  if (suite.title.indexOf("@" + wantedTag) > -1) { // eslint-disable-line no-magic-numbers
     suites.push({
       file: suite.file,
       title: suite.title,

--- a/lib/suite_capture.js
+++ b/lib/suite_capture.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var fs = require("fs");
+var _ = require("lodash");
 
 /**
  * Recursive function, takes a mocha test suite and returns a flattened list of
@@ -10,7 +11,7 @@ var fs = require("fs");
 function getSuites(suite, wantedTag) {
   var suites = [];
 
-  if ( suite.title.indexOf("@" + wantedTag) > -1 ) {
+  if (suite.title.indexOf("@" + wantedTag) > -1) {
     suites.push({
       file: suite.file,
       title: suite.title,
@@ -41,7 +42,12 @@ module.exports = function (runner, options) {
   };
 
   // traverse suite structure and flattened list of tagged suites
-  var suites = getSuites(runner.suite, options.reporterOptions.tag);
+  var suites = [];
+  var wantedTags = options.reporterOptions.tags.split(";").map(_.method("trim"));
+
+  wantedTags.forEach(function (wantedTag) {
+    suites = suites.concat(getSuites(runner.suite, wantedTag));
+  });
 
   // process .only greps
   if (options.grep) {

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -46,7 +46,7 @@ MochaTestRun.prototype.getArguments = function () {
   }
 
   if (mochaSettings.mochaArgs !== undefined) {
-    args = args.concat(mochaSettings.mochaArgs.split(' '));
+    args = args.concat(mochaSettings.mochaArgs.split(" "));
   }
 
   args = args.concat(mochaSettings.mochaTestFolders);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && mocha --slow 400 && npm run coverage && npm run check-coverage",
-    "lint": "eslint lib/** test/**",
+    "lint": "eslint lib/** test/**.js",
     "coverage": "istanbul cover _mocha -- --recursive",
     "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 90"
   },

--- a/test/get_suites.spec.js
+++ b/test/get_suites.spec.js
@@ -13,7 +13,7 @@ function getTestsFrom(specs) {
   testFramework.initialize({
     mocha_tests: specs,
     mocha_opts: path.join(specs[0], "mocha.opts"),
-    suiteTag: "suite"
+    suiteTag: "suite;multiple"
   });
   return testFramework.iterator({tempDir: path.resolve(".")});
 }
@@ -26,7 +26,7 @@ describe("suite iterator", function () {
   });
 
   it("finds suites", function () {
-    expect(suites).to.have.length(2);
+    expect(suites).to.have.length(3);
   });
 
   it("instantiates tests as Locators", function () {

--- a/test_support/suite/spec.js
+++ b/test_support/suite/spec.js
@@ -9,3 +9,6 @@ describe('Suite 2 @suite', function() {
 describe('Suite 3 (excluded)', function() {
 	it('passes', function() {});
 });
+describe('Suite 4 @multiple', function() {
+    it('passes', function() {});
+});


### PR DESCRIPTION
This PR adds the option to add a semi-colon delimited (commas are stripped by mocha) list of Suite Tags. Currently only one suite tag is supported, but with this PR it is an option to use multiple tags.

Note: I also made some small changes to get linting and unit tests to pass. They aren't really things I touched, but they should still pass!

To test:
Ensure that the unit tests pass. I updated them to support multiple tags.
